### PR TITLE
resize.test.js: remove incorrect assertion

### DIFF
--- a/test/resize.test.js
+++ b/test/resize.test.js
@@ -138,7 +138,7 @@ describe('Resize module', () => {
         assert.strictEqual(resizeResult.offenders.imageScaledDown.newHeight, 43 * 2);
     });
 
-    it.skip('should report excessive image density and resize further', async () => {
+    it('should report excessive image density and resize further', async () => {
         const image = await fs.readFile(path.resolve(__dirname, './images/jpeg-image.jpg'));
         const res = await ModulesRunner.execModuleForTest('resize', image, {
             displayWidth: 28,
@@ -153,7 +153,7 @@ describe('Resize module', () => {
                 fileSize: image.length
             }
         });
-        assert.strictEqual(res.offenders.imageExcessiveDensity.displayDensity.toFixed(5), '10.05440');
+
         assert.strictEqual(res.offenders.imageExcessiveDensity.recommendedMaxDensity, 2);
         assert.strictEqual(res.offenders.imageExcessiveDensity.recommendedWidth, 56);
         assert.strictEqual(res.offenders.imageExcessiveDensity.recommendedHeight, 86);


### PR DESCRIPTION
`offenders.imageExcessiveDensity.displayDensity` got removed in 1c8768aa34538aaf6b1b30b45e8718de521728f2

/cc @gmetais